### PR TITLE
More package cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Javascript Library for Client-side Encryption with Braintree",
   "version": "1.3.12",
   "main": "target/braintree-1.3.10.js",
+  "files": [
+    "target/"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/github/braintree-encryption.git"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/github/braintree-encryption.git"
   },
   "publishConfig": {
-    "registry": "https://npm.registry.github.com"
+    "registry": "https://npm.pkg.github.com"
   },
   "keywords": [
     "braintree",


### PR DESCRIPTION
The registry URL has changed and without the `files` key we are publishing a lot of unnecessary files to the registry.