### PR TITLE
Fix prototype-polluting vulnerability

### DIFF
--- a/target/braintree-1.3.10.js
+++ b/target/braintree-1.3.10.js
@@ -2366,13 +2366,11 @@ sjcl.random = {
       }
     }
 
-    const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
     for (i=0; i<jsTemp.length; i++) {
       j = jsTemp[i];
-      if (forbiddenKeys.includes(j)) {
-        continue;
+      if (!['__proto__', 'constructor', 'prototype'].includes(j)) {
+        delete cbs[j];
       }
-      delete cbs[j];
     }
   },
 


### PR DESCRIPTION
We are fixing a code scanning alert caused by a prototype-polluting assignment. Prototype pollution is a type of vulnerability in which an attacker is able to modify `Object.prototype`. Since most objects inherit from the compromised `Object.prototype` object, the attacker can use this to tamper with the application logic, and often escalate to remote code execution or cross-site scripting.

One way to cause prototype pollution is by modifying an object obtained via a user-controlled property name. Most objects have a special `__proto__` property that refers to `Object.prototype`. An attacker can abuse this special property to trick the application into performing unintended modifications of `Object.prototype`.

To fix the error we are preventing the `__proto__` property from being used as a key.

Code scanning alert: https://github.com/github/braintree-encryption/security/code-scanning/1
